### PR TITLE
bugfix: exportPath null when no use of eotdl dataset

### DIFF
--- a/ui/src/routes/campaigns/export/+page.svelte
+++ b/ui/src/routes/campaigns/export/+page.svelte
@@ -16,7 +16,12 @@
 
   const exportCampaign = (e) => {
     if (exportType === "folder" && !exportPath) {
-      return;
+      if (campaigns.current?.path) {
+        exportPath = `${campaigns.current?.path}/labels`.replace(/[\\/]+/g, '/');
+      }
+      else {
+        return;
+      }
     }
     e.preventDefault();
     try {
@@ -81,7 +86,7 @@
         {/if}
       </div>
     {:else}
-      <p>Something went wrong :(</p>
+      <p>Something went wrong :</p>
     {/if}
     <p>Images: {campaigns.current?.image_count}</p>
     <p>Annotations: {campaigns.current?.annotation_count}</p>


### PR DESCRIPTION
Hi,

I was testing Scaneo with my own data.
After labelling my campaign, I tried to export the labels but an error happened.
After searching in the code, it appears that the exportPath variable was null when trying to export.
This variable is set when "campaigns.current?.eotdlDatasetId" in the form but not otherwise.

So I made a small change by checking if the campaign has a path and no exportPath is set, then I create the exportPath to "{campaignPath}/labels".

Feel free to use or not.
I'm not used to pull request thus sorry if the shape of my PR is not appropriate.